### PR TITLE
Feat: compile and test only specific branch of commit (#20)

### DIFF
--- a/src/main/java/com/group21/ci/BuildManager.java
+++ b/src/main/java/com/group21/ci/BuildManager.java
@@ -25,10 +25,11 @@ public class BuildManager {
      *
      * @param repoOwner The owner of the repository.
      * @param repoName  The name of the repository.
+     * @param branchName    The branch to be tested of the repository.
      * @return true if tests pass successfully, false otherwise.
      */
     @SuppressWarnings("deprecation")
-    public static boolean runBuild(String repoOwner, String repoName) {
+    public static boolean runBuild(String repoOwner, String repoName, String branchName) {
         try {
             // Construct the repository URL dynamically
             String repoUrl = "https://github.com/" + repoOwner + "/" + repoName + ".git";
@@ -36,7 +37,7 @@ public class BuildManager {
             System.out.println("Cloning repository...");
 
             // Clone the repository into a local "repo" directory
-            Process clone = Runtime.getRuntime().exec("git clone " + repoUrl + " repo");
+            Process clone = Runtime.getRuntime().exec("git clone --branch " + branchName + " " + repoUrl + " repo");
             clone.waitFor(); // Wait for cloning to complete
 
             System.out.println("Running tests in the cloned repository...");

--- a/src/main/java/com/group21/ci/BuildWorker.java
+++ b/src/main/java/com/group21/ci/BuildWorker.java
@@ -29,7 +29,7 @@ public class BuildWorker implements Runnable {
         System.out.println("Processing job for commit: " + job.commitSHA);
 
         // Run build process and tests
-        boolean buildSuccess = BuildManager.runBuild(job.repoOwner, job.repoName);
+        boolean buildSuccess = BuildManager.runBuild(job.repoOwner, job.repoName, job.branchName);
 
         // Determine final status (pass only if both build & test succeed)
         boolean finalStatus = buildSuccess;

--- a/src/main/java/com/group21/ci/JobQueue.java
+++ b/src/main/java/com/group21/ci/JobQueue.java
@@ -19,10 +19,11 @@ public class JobQueue {
      * 
      * @param repoUrl   The URL of the repository where the commit was pushed.
      * @param commitSHA The commit SHA for which the CI job is triggered.
+     * @param branchName The name of the branch which the commit belongs to.
      */
 
-    public static void addJob(String repoOwner, String repoName, String commitSHA) {
-        BuildJob job = new BuildJob(repoOwner, repoName, commitSHA);
+    public static void addJob(String repoOwner, String repoName, String commitSHA, String branchName) {
+        BuildJob job = new BuildJob(repoOwner, repoName, commitSHA, branchName);
         queue.add(job);
         new Thread(new BuildWorker(job)).start();
     }
@@ -31,11 +32,13 @@ public class JobQueue {
         String repoOwner;
         String repoName;
         String commitSHA;
+        String branchName;
 
-        public BuildJob(String repoOwner, String repoName, String commitSHA) {
+        public BuildJob(String repoOwner, String repoName, String commitSHA, String branchName) {
             this.repoOwner = repoOwner;
             this.repoName = repoName;
             this.commitSHA = commitSHA;
+            this.branchName = branchName;
         }
     }
 

--- a/src/main/java/com/group21/ci/WebhookHandler.java
+++ b/src/main/java/com/group21/ci/WebhookHandler.java
@@ -43,13 +43,17 @@ public class WebhookHandler {
             String repoName = json.getJSONObject("repository").getString("name");
 
             String commitSHA = json.getJSONObject("head_commit").getString("id");
+            
+            String ref = json.getString("ref"); // For extracting branch name of commit
+            String branchName = ref.replace("refs/heads/", "");
 
             // Debugging output
             System.out.println("Extracted Repo Owner: " + repoOwner);
             System.out.println("Extracted Repo Name: " + repoName);
             System.out.println("Commit SHA: " + commitSHA);
+            System.out.println("Branch Name: " + branchName);
 
-            JobQueue.addJob(repoOwner, repoName, commitSHA);
+            JobQueue.addJob(repoOwner, repoName, commitSHA, branchName);
 
             // Log received webhook data
             // System.out.println("Webhook received for repo: " + repoUrl);


### PR DESCRIPTION

## Description

Compile and test the branch which the commit comes from instead of always default branch. 
added funnctionality to extract branch name from the webhook request and used the branch name during cloning so that the specific branch is compiled and tested by the server.

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing


## Related Issues

- Closes #20 
