### PR TITLE
fix: clears repo folder after finishing testing

### DIFF
--- a/src/main/java/com/group21/ci/BuildManager.java
+++ b/src/main/java/com/group21/ci/BuildManager.java
@@ -29,6 +29,7 @@ public class BuildManager {
      * - Clones the repository into a local directory.
      * - Runs `mvn test` to execute tests.
      * - Returns true if tests pass successfully, otherwise false.
+     * - Clears the cloned repository directory after execution.
      *
      * @param repoOwner The owner of the repository.
      * @param repoName  The name of the repository.
@@ -55,7 +56,8 @@ public class BuildManager {
 
             // Run Maven test
             ProcessBuilder mvnTestBuilder = new ProcessBuilder("mvn", "test");
-            mvnTestBuilder.directory(new File("repo"));
+            File repoDirectory = new File("repo");
+            mvnTestBuilder.directory(repoDirectory);
             Process mvnTest = mvnTestBuilder.start();
 
             BufferedReader reader = new BufferedReader(new InputStreamReader(mvnTest.getInputStream()));
@@ -98,7 +100,8 @@ public class BuildManager {
             logWriter.close(); // Close the log file
 
 
-
+            // Clean up: Delete the cloned repository directory
+            deleteDirectory(repoDirectory);
 
             // Return true if tests pass and build succeeds
 //            return success && mvnTest.waitFor() == 0;
@@ -109,6 +112,27 @@ public class BuildManager {
             // Print error details if build execution fails
             e.printStackTrace();
             return false;
+        }
+    }
+
+    /**
+     * Helper method to deletes a directory its contents.
+     *
+     * @param directory The directory to be deleted.
+     */
+    private static void deleteDirectory(File directory) {
+        if (directory.exists()) {
+            File[] files = directory.listFiles();
+            if (files != null) {
+                for (File file : files) {
+                    if (file.isDirectory()) {
+                        deleteDirectory(file); 
+                    } else {
+                        file.delete();
+                    }
+                }
+            }
+            directory.delete(); 
         }
     }
 }

--- a/src/test/java/com/group21/ci/BuildManagerTest.java
+++ b/src/test/java/com/group21/ci/BuildManagerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -79,5 +80,22 @@ class BuildManagerTest {
         logWriter.close();
 
         return success; // Return success based on the test scenario
+    }
+
+    @Test
+    void testDeleteDirectory() throws IOException {
+        // setup a test directory and a file inside it
+        File testDirectory = new File(TEST_REPO_DIR);
+        File testFile = new File(testDirectory, "testFile.txt");
+        testFile.createNewFile();
+
+        assertTrue(testDirectory.exists(), "Test directory should exist before deletion.");
+        assertTrue(testFile.exists(), "Test file should exist before deletion.");
+
+        deleteDirectory(testDirectory);
+
+        // assert test file and directory deleted
+        assertFalse(testFile.exists(), "Test file should be deleted.");
+        assertFalse(testDirectory.exists(), "Test directory should be deleted.");
     }
 }


### PR DESCRIPTION
## Description

A smaller change that clears/deletes the repo folder after testing has finished, in order for new repos to be cloned in a clean environment. 

## Testing
The behaviour of the deleteDirectory function has been unit tested. 

## Issues
- Closes #21 

## Notes
Unfortunately has not been tested in action, but it logically has no bad side effects