### PR TITLE
fix: Fix the test process in our ci sever (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,62 @@ curl -X PATCH -H "Authorization: token $GITHUB_TOKEN" \
      -d "{\"config\": {\"url\": \"$NGROK_URL/webhook\", \"content_type\": \"json\"}}" \
      https://api.github.com/repos/YOUR_GITHUB_USERNAME/YOUR_REPO_NAME/hooks/YOUR_WEBHOOK_ID
 ```
+
+### For P+ feature
+#### Step 1: Start MySQL Database
+The CI Server requires a MySQL database to store build results.
+
+Option 1: Run MySQL in Docker
+```shell
+docker-compose up -d
+```
+This will start MySQL using docker-compose.yml.
+
+#### Step 2: Verify Database is Running
+Connect to MySQL and verify the database is correctly initialized:
+
+You should modify **src/main/resources/hibernate.cfg.xml** with your own password for your MySQL sever. Change **yourpassword** with your own password.
+```plaintext
+<property name="hibernate.connection.password">yourpassword</property>
+```
+Then run:
+```shell
+mysql -u root -p
+```
+Then, run:
+```sql
+SHOW DATABASES;
+USE ci_results;
+SHOW TABLES;
+```
+Ensure **test_results** table exists.
+
+#### Step 3: Build and Run the CI Server
+```shell
+mvn clean install
+mvn exec:java -Dexec.mainClass="com.group21.ci.ContinuousIntegrationServer"
+```
+Expected output:
+```plaintext
+CI Server running on port 8080...
+```
+
+#### Step 4: Access the CI Server
+View Build History Page
+  - Open a browser and go to:
+      ```plaintext
+      http://localhost:8080/api/history
+      ```
+  - If builds exist, they will be listed with commit IDs.
+
+View Individual Build Details
+
+- Click on any commit SHA from the history page.
+  - It will open a page like:
+    ```plaintext
+    http://localhost:8080/builds/{commitSha}
+    ```
+
 ## Contributions
 
 ### **🔹 Team Members**

--- a/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -1,54 +1,46 @@
 package com.group21.ci;
 
-
 import com.group21.ci.dao.TestResultDAO;
 import com.group21.ci.entity.TestResultEntity;
-import org.eclipse.jetty.server.Server;
+//import com.google.gson.Gson;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.util.ajax.JSON;
 
-
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.ServletException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-
 /**
- * Continuous Integration Server that listens for webhooks, serves build history, and serves a static HTML page.
+ * Continuous Integration Server
+ * - Handles webhook events
+ * - Serves the history of past builds
  */
 public class ContinuousIntegrationServer extends AbstractHandler {
     private static final TestResultDAO testResultDAO = new TestResultDAO();
-
+    private static final JSON json = new JSON(); // JSON Serializer
 
     public static void main(String[] args) throws Exception {
         Server server = new Server(8080);
         server.setHandler(new ContinuousIntegrationServer());
-
 
         server.start();
         System.out.println("CI Server running on port 8080...");
         server.join();
     }
 
-
     @Override
     public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
             throws IOException, ServletException {
 
-
-        // Set response content type and status
-        response.setContentType("text/html;charset=utf-8");
-        response.setStatus(HttpServletResponse.SC_OK);
+        response.setCharacterEncoding("UTF-8");
         baseRequest.setHandled(true);
-
 
         // Handle webhook request
         if ("/webhook".equals(target) && "POST".equalsIgnoreCase(request.getMethod())) {
@@ -57,72 +49,106 @@ public class ContinuousIntegrationServer extends AbstractHandler {
             return;
         }
 
-
-        // Handle API request for build history
+        // Handle API request for build history (All builds)
         if ("/api/history".equals(target)) {
-            try {
-                List<TestResultEntity> results = testResultDAO.getAllTestResults();
-                String json = new JSON().toJSON(results);
-
-
-                response.setContentType("application/json");
-                response.getWriter().println(json);
-            } catch (Exception e) {
-                response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-                response.getWriter().println("{\"error\": \"Failed to fetch build history\"}");
-            }
+            handleBuildHistory(response);
             return;
         }
 
+        // Handle API request for a specific build details
+        if (target.startsWith("/api/history/")) {
+            String commitSha = target.substring("/api/history/".length());
+            handleBuildDetails(response, commitSha);
+            return;
+        }
 
-        // Serve history page
+        // Serve the build history HTML page
         if ("/history".equals(target)) {
-            try {
-                Path historyPath = Paths.get(System.getProperty("user.dir"), "./src/main/resources/static/history.html");
-//            String historyPage = Files.readString(Path.of("resources/static/history.html"));
-                String historyPage = new String(Files.readAllBytes(historyPath));
-                response.setContentType("text/html");
-                response.getWriter().println(historyPage);
-                handleBuildHistory(response);
-            } catch (IOException e) {
-                response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-                response.getWriter().println("{\"error\": \"Failed to load history page\"}");
-            }
+            serveHistoryPage(response);
             return;
         }
+//        if ("/history".equals(target)) {
+//            try {
+//                Path historyPath = Paths.get(System.getProperty("user.dir"), "./src/main/resources/static/history.html");
+//                String historyPage = new String(Files.readAllBytes(historyPath));
+//
+//                response.setContentType("text/html");
+//                response.getWriter().println(historyPage);
+//            } catch (IOException e) {
+//                response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+//                response.getWriter().println("{\"error\": \"Failed to load history page\"}");
+//            }
+//            return;
+//        }
 
+        // Serve a specific build details page
+        if (target.startsWith("/builds/")) {
+            String commitSha = target.substring("/builds/".length());
+            serveBuildDetailsPage(response, commitSha);
+            return;
+        }
 
         // Default response for unknown endpoints
         response.setStatus(HttpServletResponse.SC_NOT_FOUND);
         response.getWriter().println("{\"error\": \"Invalid endpoint\"}");
     }
 
+    /**
+     * Returns all past builds in JSON format.
+     */
+//    private void handleBuildHistory(HttpServletResponse response) throws IOException {
+//        try {
+//            List<TestResultEntity> results = testResultDAO.getAllTestResults();
+//            response.setContentType("application/json");
+//            response.getWriter().println(json.toJSON(results));
+//        } catch (Exception e) {
+//            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+//            response.getWriter().println("{\"error\": \"Failed to fetch build history\"}");
+//        }
+//    }
 
     /**
-     * Serves a static HTML page displaying build history.
+     * Returns details for a specific build in JSON format.
      */
-    private void handleBuildHistoryPage(HttpServletResponse response) throws IOException {
-        response.setContentType("text/html;charset=utf-8");
-
-
-        String htmlFilePath = "src/main/resources/history.html"; // Path to your HTML file
-        if (Files.exists(Paths.get(htmlFilePath))) {
-            String htmlContent = new String(Files.readAllBytes(Paths.get(htmlFilePath)));
-            response.getWriter().println(htmlContent);
-        } else {
-            response.getWriter().println("<html><body><h2>History Page Not Found</h2></body></html>");
+    private void handleBuildDetails(HttpServletResponse response, String commitSha) throws IOException {
+        try {
+            TestResultEntity result = testResultDAO.getTestResultById(Integer.parseInt(commitSha));
+            if (result != null) {
+                response.setContentType("application/json");
+                response.getWriter().println(json.toJSON(result));
+            } else {
+                response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                response.getWriter().println("{\"error\": \"Build not found\"}");
+            }
+        } catch (Exception e) {
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.getWriter().println("{\"error\": \"Failed to fetch build details\"}");
         }
     }
 
+    /**
+     * Serves the HTML page that displays build history.
+     */
+    private void serveHistoryPage(HttpServletResponse response) throws IOException {
+        try {
+            Path historyPath = Paths.get(System.getProperty("user.dir"), "./src/main/resources/static/history.html");
+            String historyPage = new String(Files.readAllBytes(historyPath));
+            response.setContentType("text/html");
+            response.getWriter().println(historyPage);
+        } catch (IOException e) {
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.getWriter().println("{\"error\": \"Failed to load history page\"}");
+        }
+    }
 
     /**
-     * Retrieves and returns the list of past builds as JSON.
+     * Serves an HTML page for a specific build's details.
      */
     private void handleBuildHistory(HttpServletResponse response) throws IOException {
         List<TestResultEntity> buildResults = testResultDAO.getAllTestResults();
+        System.out.println("Building history page with " + buildResults.size() + " entries."); // 添加日志
+
         StringBuilder html = new StringBuilder("<html><body><h2>Build History</h2><ul>");
-
-
         for (TestResultEntity result : buildResults) {
             html.append("<li><a href='/builds/")
                     .append(result.getCommitSha())
@@ -134,58 +160,33 @@ public class ContinuousIntegrationServer extends AbstractHandler {
                     .append(result.getTimestamp())
                     .append("</li>");
         }
-
-
         html.append("</ul></body></html>");
+
+        response.getWriter().println(html.toString());
+    }
+
+    private void serveBuildDetailsPage(HttpServletResponse response, String commitSha) throws IOException {
+        TestResultEntity result = testResultDAO.getTestResultByCommitSha(commitSha);
+
+        if (result == null) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            response.getWriter().println("<html><body><h2>Build Not Found</h2></body></html>");
+            return;
+        }
+
+        StringBuilder html = new StringBuilder("<html><body>");
+        html.append("<h2>Build Details</h2>");
+        html.append("<p><strong>Commit SHA:</strong> ").append(result.getCommitSha()).append("</p>");
+        html.append("<p><strong>Status:</strong> ").append(result.getStatus()).append("</p>");
+        html.append("<p><strong>Timestamp:</strong> ").append(result.getTimestamp()).append("</p>");
+//        html.append("<h3>Test Log:</h3><pre>").append(result.getTestLog()).append("</pre>");
+        html.append("<a href='/api/history'>Back to Build History</a>");
+        html.append("</body></html>");
+
         response.getWriter().println(html.toString());
     }
 
 
-    /**
-     * Retrieves and returns details of a specific build as JSON.
-     */
-    private void handleBuildDetails(String commitSha, HttpServletResponse response) throws IOException {
-        TestResultEntity result = testResultDAO.getResultByCommit(commitSha);
-        if (result == null) {
-            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-            response.getWriter().println("{\"error\": \"Build not found\"}");
-            return;
-        }
-
-
-        response.setContentType("text/html;charset=utf-8");
-        String htmlResponse = "<html><body><h2>Build Details</h2>" +
-                "<p><b>Commit:</b> " + result.getCommitSha() + "</p>" +
-                "<p><b>Status:</b> " + result.getStatus().toString() + "</p>" +
-                "<p><b>Timestamp:</b> " + result.getTimestamp() + "</p>" +
-//                "<pre>" + result.getLogs() + "</pre>" +
-                "</body></html>";
-        response.getWriter().println(htmlResponse);
-    }
-
-
-    private String generateHistoryPage() {
-        List<TestResultEntity> testResults = testResultDAO.getAllTestResults();
-        StringBuilder html = new StringBuilder("<html><head><title>Build History</title></head><body>");
-
-
-        html.append("<h1>Build History</h1>");
-        html.append("<table border='1'><tr><th>Commit ID</th><th>Build Date</th><th>Status</th><th>Logs</th></tr>");
-
-
-        for (TestResultEntity result : testResults) {
-            html.append("<tr>")
-                    .append("<td>").append(result.getCommitSha()).append("</td>")
-                    .append("<td>").append(result.getTimestamp()).append("</td>")
-                    .append("<td>").append(result.getStatus()).append("</td>")
-                    .append("<td><a href='/build/").append(result.getId()).append("'>View Logs</a></td>")
-                    .append("</tr>");
-        }
-
-
-        html.append("</table></body></html>");
-        return html.toString();
-    }
-
-
 }
+
+


### PR DESCRIPTION
## Description
I fixed the test in our ci sever, now it can **clone** the repo and implement **"mvn test"** correctly. If there are test failures, it will notify in the github and store the build status as FAILURE in the database.
### The notification:
<img width="951" alt="Screenshot 2025-02-13 at 16 52 03" src="https://github.com/user-attachments/assets/c9d78bc5-50b1-469b-9a61-a8cb809dda53" />
<img width="1583" alt="Screenshot 2025-02-13 at 16 52 16" src="https://github.com/user-attachments/assets/1f95cbf0-c660-40d2-8913-606ad8b2c226" />

## New feature
I updated the front-end to show the notification clearly. the simple front-end looks like:
### For the build history:
<img width="902" alt="Screenshot 2025-02-13 at 17 40 49" src="https://github.com/user-attachments/assets/c636558d-5894-4e14-a83f-ea511ab44c07" />
### For a single build detail:
<img width="802" alt="Screenshot 2025-02-13 at 17 40 40" src="https://github.com/user-attachments/assets/ae0d8dc2-0e4e-4f43-9d50-f45d115bd63e" />

## Related Issue
Close #50 
